### PR TITLE
add: multiple elements support

### DIFF
--- a/meow_todo_list.py
+++ b/meow_todo_list.py
@@ -22,7 +22,7 @@ def add_todo(todo, cat):
 
     save_todos(todos)
 
-    return f"Todo list updated with: *{todo}*"
+    return f"Todo list updated with: *{', '.join(todo)}*"
 
 
 @tool(return_direct=True)

--- a/meow_todo_list.py
+++ b/meow_todo_list.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel
+from ast import literal_eval
 import time
 
 from cat.mad_hatter.decorators import tool, hook
@@ -9,13 +10,15 @@ from .todo import get_todos, save_todos, stringify_todos
 
 @tool(return_direct=True)
 def add_todo(todo, cat):
-    """Add item to the todo list. User may say "Remeber to..." or similar. Argument "todo" is a string representing the item."""
+    """Add item or multiple items to the todo list. User may say "Remeber to..." or similar. Argument "todo" is an array of items."""
 
+    todo = literal_eval(todo)
     todos = get_todos()
-    todos.append({
-        "created": time.time(),
-        "description": str(todo)
-    })
+    for elem in todo:
+        todos.append({
+            "created": time.time(),
+            "description": str(elem)
+        })
 
     save_todos(todos)
 
@@ -24,22 +27,18 @@ def add_todo(todo, cat):
 
 @tool(return_direct=True)
 def remove_todo(todo, cat):
-    """Remove / delete item from the todo list. "todo" is the item to remove."""
-
+    """Remove / delete item or multiple items from the todo list. "todo" is the array of items to remove."""
     todos = get_todos()
 
     # TODO: should we use embeddings?
     prompt = "Given this list of items:"
     for t_index, t in enumerate(todos):
         prompt += f"\n {t_index}. {t['description']}"
-    prompt += f"\n\nThe most similar item to `{todo}` is item number... (reply ONLY with the number, no letters or points)"
-    
-    
+    prompt += f"\n\nThe most similar items to `{todo}` are items number... (reply ONLY with an array with the number or numbers, no letters or points)"
     try:
         to_remove = cat.llm(prompt)
-        index_to_remove = int(to_remove)
-
-        todos.pop(index_to_remove)
+        index_to_remove = literal_eval(to_remove)
+        todos = [el for idx, el in enumerate(todos) if idx not in index_to_remove]
         save_todos(todos)
     except Exception as e:
         log(e, "ERROR")


### PR DESCRIPTION
## Add

Hi Piero,
I added multiple element support to the todo list plugin.
Now, the cat is able to add/remove multiple elements to/from the list.
For example if you say:
`Add to my list going to the market, listening to music and calling grandma`
All three elements will be added to the list. Similar is for removing elements.
I am not sure if you think it's useful 😸 but, here it is in case

![new_feature](https://github.com/pieroit/meow-todo-list/assets/9247877/ff7b0bb7-c696-4fd5-ad5f-3a3683ee7472)


### Note
For single add/remove of an element, it works as before
